### PR TITLE
Update StartProcess.cs to run DOS applications such as cmd.exe and ping.exe

### DIFF
--- a/AdvancedConnectPlugin/Tools/StartProcess.cs
+++ b/AdvancedConnectPlugin/Tools/StartProcess.cs
@@ -20,10 +20,17 @@ namespace AdvancedConnectPlugin.Tools
         public static void Start(String path, String arguments)
         {
             using (Process process = new Process()) {
+                if (arguments.EndsWith("dos"))
+                {
+                    arguments = arguments.Remove(arguments.Length - 3).Trim();
+                }
+                else
+                {
+                    process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                    process.StartInfo.CreateNoWindow = true;
+                }
                 process.StartInfo.FileName = path;
                 process.StartInfo.Arguments = arguments;
-                process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-                process.StartInfo.CreateNoWindow = true;
                 process.StartInfo.UseShellExecute = false;
                 process.Start();
             }


### PR DESCRIPTION
DOS applications can be run by adding the "dos" parameter at the end of the "Commandline Options" section. Tested on Windows 11 24H2.

For example, ping can be run in two ways:

{URL:HOST} -t dos

or

{URL:HOST} -tdos