### PR TITLE
catch process start failures instead of terminating KeePass

### DIFF
--- a/AdvancedConnectPlugin/Data/ConnectionItem.cs
+++ b/AdvancedConnectPlugin/Data/ConnectionItem.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Windows.Forms;
 
 namespace AdvancedConnectPlugin.Data
 {
@@ -44,6 +45,44 @@ namespace AdvancedConnectPlugin.Data
             resolvedPathOrOptions = Environment.ExpandEnvironmentVariables(resolvedPathOrOptions);
 
             return resolvedPathOrOptions;
+        }
+
+        /**
+         * Reports a failed application start to the user.
+         * Connections are started on a background thread, where an unhandled exception
+         * would terminate the whole KeePass process, so nothing may escape from here.
+         */
+        protected void showStartError(String applicationPath, Exception startException)
+        {
+            try
+            {
+                //Resolve the KeePass main window to marshal the message box onto the UI thread
+                Form mainWindow = null;
+                if (this.plugin != null && this.plugin.keepassHost != null)
+                {
+                    mainWindow = this.plugin.keepassHost.MainWindow;
+                }
+
+                MethodInvoker showMessage = delegate
+                {
+                    MessageBox.Show(("Application '" + applicationPath + "' could not be started."
+                        + Environment.NewLine + Environment.NewLine + startException.Message),
+                        "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                };
+
+                if (mainWindow != null && mainWindow.IsHandleCreated && mainWindow.InvokeRequired)
+                {
+                    mainWindow.Invoke(showMessage);
+                }
+                else
+                {
+                    showMessage();
+                }
+            }
+            catch (Exception)
+            {
+                //Reporting a failure must never take KeePass down; deliberately ignored
+            }
         }
 
     }

--- a/AdvancedConnectPlugin/Data/CustomConnectionItem.cs
+++ b/AdvancedConnectPlugin/Data/CustomConnectionItem.cs
@@ -49,9 +49,17 @@ namespace AdvancedConnectPlugin.Data
                 new Thread(() =>
                 {
                     Thread.CurrentThread.IsBackground = true; //Background threads will stop automatically on program close
-                    
-                    //Fill placeholders in options and start programm
-                    StartProcess.Start(fillPlaceholders(this.application.path), fillPlaceholders(this.customConnectionOptions));
+
+                    try
+                    {
+                        //Fill placeholders in options and start programm
+                        StartProcess.Start(fillPlaceholders(this.application.path), fillPlaceholders(this.customConnectionOptions));
+                    }
+                    catch (Exception startException)
+                    {
+                        //An unhandled exception on this thread would terminate KeePass
+                        showStartError(this.application.path, startException);
+                    }
                 }).Start();
 
 

--- a/AdvancedConnectPlugin/Data/RDPConnectionItem.cs
+++ b/AdvancedConnectPlugin/Data/RDPConnectionItem.cs
@@ -61,20 +61,28 @@ namespace AdvancedConnectPlugin.Data
                     {
                         Thread.CurrentThread.IsBackground = true; //Background threads will stop automatically on program close
 
-                        //Fill placeholders in options and start programm (cmdkey sets the rdp credentials)
-                        StartProcess.Start(RDPConnectionItem.pathToCMDKey, fillPlaceholders(buildAddingCmdkeyParameter()));
+                        try
+                        {
+                            //Fill placeholders in options and start programm (cmdkey sets the rdp credentials)
+                            StartProcess.Start(RDPConnectionItem.pathToCMDKey, fillPlaceholders(buildAddingCmdkeyParameter()));
 
-                        //Wait before RDP start
-                        Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                            //Wait before RDP start
+                            Thread.Sleep(TimeSpan.FromMilliseconds(500));
 
-                        //Fill placeholders in options and start remote desktop with thread delay
-                        StartProcess.Start(RDPConnectionItem.pathToRemoteDesktop, fillPlaceholders(buildRDPParameter()));
+                            //Fill placeholders in options and start remote desktop with thread delay
+                            StartProcess.Start(RDPConnectionItem.pathToRemoteDesktop, fillPlaceholders(buildRDPParameter()));
 
-                        //Wait before credential remove
-                        Thread.Sleep(TimeSpan.FromMilliseconds(5000));
+                            //Wait before credential remove
+                            Thread.Sleep(TimeSpan.FromMilliseconds(5000));
 
-                        //Fill placeholders in options and start programm with thread delay(cmdkey removes the previous set rdp credentials)
-                        StartProcess.Start(RDPConnectionItem.pathToCMDKey, fillPlaceholders(buildRemovingCmdkeyParameter()));
+                            //Fill placeholders in options and start programm with thread delay(cmdkey removes the previous set rdp credentials)
+                            StartProcess.Start(RDPConnectionItem.pathToCMDKey, fillPlaceholders(buildRemovingCmdkeyParameter()));
+                        }
+                        catch (Exception startException)
+                        {
+                            //An unhandled exception on this thread would terminate KeePass
+                            showStartError(RDPConnectionItem.pathToRemoteDesktop, startException);
+                        }
                     }).Start();
 
                     return true;


### PR DESCRIPTION
Fixes #23

Starting a configured application happens on a background thread with no exception
handler. When `Process.Start` fails, the unhandled exception terminates the whole
KeePass process — unsaved database changes are lost.

### Change

- `ConnectionItem` gets a `showStartError` helper that marshals the message onto the UI
  thread via the main window, and swallows anything thrown while reporting, so the error
  path itself can never terminate the process either
- both thread bodies (`CustomConnectionItem`, `RDPConnectionItem`) are wrapped in
  `try`/`catch`

No change on the success path. Nothing else touched.

### Note on the diff

Most of the `RDPConnectionItem` diff is indentation from wrapping the existing block —
viewing with `?w=1` shows the actual change is four lines.

### Verified

- compiles with `csc /langversion:5` against `Libs/KeePass.exe` (2.28) with `/warnaserror`,
  no warnings
- `.plgx` builds
- reproduced the crash before the change; after it, KeePass shows an error dialog and
  stays open. Confirmed independently: KeePass recompiled the new sources into its plugin
  cache, and no new crash dump was written. KeePass 2.61.1, Windows 11

### Deliberately out of scope

- shortcut (`.lnk`) support — that is the feature deferred in #8; this is only about
  surviving a failed start
- the RDP credential cleanup does not run when the start fails. That was already the case
  before (the process died instead), so this is not a regression, but it belongs in its
  own change
