### PR TITLE
Drop unresolved custom field references instead of passing them on

### DIFF
--- a/AdvancedConnectPlugin/Data/ConnectionItem.cs
+++ b/AdvancedConnectPlugin/Data/ConnectionItem.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace AdvancedConnectPlugin.Data
 {
@@ -25,9 +26,16 @@ namespace AdvancedConnectPlugin.Data
         protected PwDatabase keepassDatabase = null;
         protected PwEntry keepassEntry = null;
 
+        //Matches keepass custom field references ({S:Name}) the compiling engine could not resolve.
+        //Deliberately limited to that form, because command lines legitimately contain other braces
+        //(for example "find . -exec rm {} \;" or json fragments), which must not be touched.
+        private static readonly Regex unresolvedFieldPlaceholder =
+            new Regex(@"\{S:[^}]*\}", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
 
         /**
-         * Replaces all placeholders with keepass compiling engine and replace os environment variables
+         * Replaces all placeholders with keepass compiling engine and replace os environment variables.
+         * Custom field references that stay unresolved are removed instead of being passed on literally.
          */
         protected String fillPlaceholders(String applicationOptions)
         {
@@ -39,6 +47,9 @@ namespace AdvancedConnectPlugin.Data
             SprCompileFlags compileFlags = SprCompileFlags.All; // Which placeholders should be replaced
             SprContext replaceContext = new SprContext(this.keepassEntry, this.keepassDatabase, compileFlags, encodeAsAutoType, encodeQuotesForCommandline);
             resolvedPathOrOptions = SprEngine.Compile(applicationOptions, replaceContext);
+
+            //Drop custom field references that could not be resolved (missing or misspelled field)
+            resolvedPathOrOptions = unresolvedFieldPlaceholder.Replace(resolvedPathOrOptions, String.Empty);
 
             //Resolv OS variables
             resolvedPathOrOptions = Environment.ExpandEnvironmentVariables(resolvedPathOrOptions);


### PR DESCRIPTION
Fixes #19

Custom field references that the placeholder engine cannot resolve are currently passed on to the started application literally, for example:

    /usr/bin/sudo /usr/sbin/openconnect {s:Connection-UserAgent}

`SprEngine.Compile` leaves unresolvable placeholders in place, and `fillPlaceholders` does not post-process the result — so a missing or misspelled custom field ends up as an argument instead of disappearing.

### Change

One regular expression in `ConnectionItem.fillPlaceholders`, applied after the placeholder engine has run: remaining `{S:...}` references are removed.

### Why only `{S:...}`

Command lines legitimately contain braces — `xargs -I {} echo {}`, `awk '{print $1}'`, json fragments. Stripping everything that looks like `{...}` would break those.

`{S:...}` is the only placeholder form that can realistically survive compilation:
KeePass's own placeholders (`{USERNAME}`, `{PASSWORD}`, `{TITLE}`, ...) exist on every entry and always resolve.

### Empty fields are not affected

Only references to fields the entry does **not have** are removed. A field that exists but is empty is already substituted with an empty string by the placeholder engine, so it never reaches this code.
Measured against `Libs/KeePass.exe`:

| input | `SprEngine.Compile` result |
|---|---|
| `{S:Connection-Address}` (field set) | `host.example` |
| `{S:Connection-Empty}` (field present, empty) | *(empty)* |
| `{S:Connection-Missing}` (no such field) | `{S:Connection-Missing}` |

So this change is limited to the third row — a missing or misspelled field name.

### Verified

Behaviour of the expression, matched case-insensitively:

| input | result |
|---|---|
| `openconnect {S:Connection-UserAgent}` | `openconnect ` |
| `{s:lowercase} is gone too` | ` is gone too` |
| `-S {S:A} -d {S:B} -U x` | `-S  -d  -U x` |
| `xargs -I {} echo {}` | unchanged |
| `curl -d '{"k":"v"}' http://h` | unchanged |
| `awk '{print $1}' file` | unchanged |
| `-ssh {USERNAME}@host -pw {PASSWORD}` | unchanged |

Compiles with `csc /langversion:5` against `Libs/KeePass.exe` (2.28) with `/warnaserror`, no warnings; `.plgx` builds.

### Note

This removes the reference itself, not a surrounding option it may belong to. That matches the request in #19, where the custom field holds a complete optional fragment.