### PR TITLE
Optionally warn when a referenced custom field is missing

### DIFF
--- a/AdvancedConnectPlugin/Data/ConnectionItem.cs
+++ b/AdvancedConnectPlugin/Data/ConnectionItem.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Windows.Forms;
 
 namespace AdvancedConnectPlugin.Data
 {
@@ -31,6 +32,11 @@ namespace AdvancedConnectPlugin.Data
         //(for example "find . -exec rm {} \;" or json fragments), which must not be touched.
         private static readonly Regex unresolvedFieldPlaceholder =
             new Regex(@"\{S:[^}]*\}", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+        //Collects the references removed while resolving one connection start. fillPlaceholders is
+        //called several times per start (path, options, and three times for rdp), so the warning is
+        //reported once for the whole start instead of once per call.
+        private readonly List<String> removedFieldReferences = new List<String>();
 
 
         /**
@@ -49,12 +55,72 @@ namespace AdvancedConnectPlugin.Data
             resolvedPathOrOptions = SprEngine.Compile(applicationOptions, replaceContext);
 
             //Drop custom field references that could not be resolved (missing or misspelled field)
-            resolvedPathOrOptions = unresolvedFieldPlaceholder.Replace(resolvedPathOrOptions, String.Empty);
+            //and remember them, so the user can be told about it once the start is prepared
+            resolvedPathOrOptions = unresolvedFieldPlaceholder.Replace(resolvedPathOrOptions, delegate(Match removedReference)
+            {
+                if (!this.removedFieldReferences.Contains(removedReference.Value))
+                {
+                    this.removedFieldReferences.Add(removedReference.Value);
+                }
+                return String.Empty;
+            });
 
             //Resolv OS variables
             resolvedPathOrOptions = Environment.ExpandEnvironmentVariables(resolvedPathOrOptions);
 
             return resolvedPathOrOptions;
+        }
+
+        /**
+         * Tells the user which custom field references were removed, unless the warning is switched
+         * off in the options. Called after all placeholders of one start have been resolved and
+         * before the application is launched. Runs on a background thread, so the dialog is
+         * marshalled onto the user interface thread and nothing is allowed to escape.
+         */
+        protected void showMissingFieldWarning()
+        {
+            try
+            {
+                if (this.removedFieldReferences.Count == 0) { return; }
+                if (this.plugin == null || this.plugin.settings == null) { return; }
+                if (!this.plugin.settings.warnOnMissingFieldReference) { this.removedFieldReferences.Clear(); return; }
+
+                StringBuilder warning = new StringBuilder();
+                warning.Append("The following custom fields do not exist on this entry and were removed from the command line:");
+                warning.Append(Environment.NewLine);
+                foreach (String removedReference in this.removedFieldReferences)
+                {
+                    warning.Append(Environment.NewLine);
+                    warning.Append("    ");
+                    warning.Append(removedReference);
+                }
+                warning.Append(Environment.NewLine);
+                warning.Append(Environment.NewLine);
+                warning.Append("You can switch this warning off in the AdvancedConnect options.");
+
+                Form mainWindow = (this.plugin.keepassHost != null) ? this.plugin.keepassHost.MainWindow : null;
+                MethodInvoker showMessage = delegate
+                {
+                    MessageBox.Show(warning.ToString(), "AdvancedConnect", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                };
+
+                if (mainWindow != null && mainWindow.IsHandleCreated && mainWindow.InvokeRequired)
+                {
+                    mainWindow.Invoke(showMessage);
+                }
+                else
+                {
+                    showMessage();
+                }
+            }
+            catch (Exception)
+            {
+                //Warning the user must never take KeePass down; deliberately ignored
+            }
+            finally
+            {
+                this.removedFieldReferences.Clear();
+            }
         }
 
     }

--- a/AdvancedConnectPlugin/Data/ConnectionItem.cs
+++ b/AdvancedConnectPlugin/Data/ConnectionItem.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace AdvancedConnectPlugin.Data
 {
@@ -25,9 +26,16 @@ namespace AdvancedConnectPlugin.Data
         protected PwDatabase keepassDatabase = null;
         protected PwEntry keepassEntry = null;
 
+        //Matches keepass custom field references ({S:Name}) the compiling engine could not resolve.
+        //Deliberately limited to that form, because command lines legitimately contain other braces
+        //(for example "find . -exec rm {} \;" or json fragments), which must not be touched.
+        private static readonly Regex unresolvedFieldPlaceholder =
+            new Regex(@"\{S:[^}]*\}", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
 
         /**
-         * Replaces all placeholders with keepass compiling engine and replace os environment variables
+         * Replaces all placeholders with keepass compiling engine and replace os environment variables.
+         * Custom field references that stay unresolved are removed instead of being passed on literally.
          */
         protected String fillPlaceholders(String applicationOptions)
         {
@@ -39,6 +47,9 @@ namespace AdvancedConnectPlugin.Data
             SprCompileFlags compileFlags = SprCompileFlags.All; // Which placeholders should be replaced
             SprContext replaceContext = new SprContext(this.keepassEntry, this.keepassDatabase, compileFlags, encodeAsAutoType, encodeQuotesForCommandline);
             resolvedPathOrOptions = SprEngine.Compile(applicationOptions, replaceContext);
+
+            //Drop custom field references that could not be resolved (missing or misspelled field)
+            resolvedPathOrOptions = unresolvedFieldPlaceholder.Replace(resolvedPathOrOptions, String.Empty);
 
             //Resolv OS variables
             resolvedPathOrOptions = Environment.ExpandEnvironmentVariables(resolvedPathOrOptions);

--- a/AdvancedConnectPlugin/Data/CustomConnectionItem.cs
+++ b/AdvancedConnectPlugin/Data/CustomConnectionItem.cs
@@ -50,8 +50,13 @@ namespace AdvancedConnectPlugin.Data
                 {
                     Thread.CurrentThread.IsBackground = true; //Background threads will stop automatically on program close
                     
-                    //Fill placeholders in options and start programm
-                    StartProcess.Start(fillPlaceholders(this.application.path), fillPlaceholders(this.customConnectionOptions));
+                    //Fill placeholders in path and options first, so removed field references can be reported once
+                    String resolvedPath = fillPlaceholders(this.application.path);
+                    String resolvedOptions = fillPlaceholders(this.customConnectionOptions);
+                    showMissingFieldWarning();
+
+                    //Start programm
+                    StartProcess.Start(resolvedPath, resolvedOptions);
                 }).Start();
 
 

--- a/AdvancedConnectPlugin/Data/RDPConnectionItem.cs
+++ b/AdvancedConnectPlugin/Data/RDPConnectionItem.cs
@@ -61,20 +61,26 @@ namespace AdvancedConnectPlugin.Data
                     {
                         Thread.CurrentThread.IsBackground = true; //Background threads will stop automatically on program close
 
-                        //Fill placeholders in options and start programm (cmdkey sets the rdp credentials)
-                        StartProcess.Start(RDPConnectionItem.pathToCMDKey, fillPlaceholders(buildAddingCmdkeyParameter()));
+                        //Fill placeholders in all parameters first, so removed field references can be reported once
+                        String addCredentialParameter = fillPlaceholders(buildAddingCmdkeyParameter());
+                        String remoteDesktopParameter = fillPlaceholders(buildRDPParameter());
+                        String removeCredentialParameter = fillPlaceholders(buildRemovingCmdkeyParameter());
+                        showMissingFieldWarning();
+
+                        //Start programm (cmdkey sets the rdp credentials)
+                        StartProcess.Start(RDPConnectionItem.pathToCMDKey, addCredentialParameter);
 
                         //Wait before RDP start
                         Thread.Sleep(TimeSpan.FromMilliseconds(500));
 
-                        //Fill placeholders in options and start remote desktop with thread delay
-                        StartProcess.Start(RDPConnectionItem.pathToRemoteDesktop, fillPlaceholders(buildRDPParameter()));
+                        //Start remote desktop with thread delay
+                        StartProcess.Start(RDPConnectionItem.pathToRemoteDesktop, remoteDesktopParameter);
 
                         //Wait before credential remove
                         Thread.Sleep(TimeSpan.FromMilliseconds(5000));
 
-                        //Fill placeholders in options and start programm with thread delay(cmdkey removes the previous set rdp credentials)
-                        StartProcess.Start(RDPConnectionItem.pathToCMDKey, fillPlaceholders(buildRemovingCmdkeyParameter()));
+                        //Start programm with thread delay (cmdkey removes the previous set rdp credentials)
+                        StartProcess.Start(RDPConnectionItem.pathToCMDKey, removeCredentialParameter);
                     }).Start();
 
                     return true;

--- a/AdvancedConnectPlugin/Data/Settings.cs
+++ b/AdvancedConnectPlugin/Data/Settings.cs
@@ -42,6 +42,11 @@ namespace AdvancedConnectPlugin.Data
         [XmlElement(ElementName = "RDPCustomParameter")]
         public String rdpCustomParameter = String.Empty;
 
+        //Defaults to true, so configuration files written by earlier versions (which do not contain
+        //this element) keep the warning enabled without needing a migration
+        [XmlElement(ElementName = "WarnOnMissingFieldReference")]
+        public Boolean warnOnMissingFieldReference = true;
+
         [XmlArray("ApplicationList"),XmlArrayItem(Type = typeof(ApplicationItem))]
         public SortableBindingList<ApplicationItem> applicationsBindingList = new SortableBindingList<ApplicationItem>();
 

--- a/AdvancedConnectPlugin/GUI/Options.Designer.cs
+++ b/AdvancedConnectPlugin/GUI/Options.Designer.cs
@@ -54,6 +54,7 @@
             this.labelRDPConnectionParameter = new System.Windows.Forms.Label();
             this.labelRDPInfo = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
+            this.checkBoxWarnMissingField = new System.Windows.Forms.CheckBox();
             this.tabControl.SuspendLayout();
             this.tabPageMain.SuspendLayout();
             this.groupBoxFieldMappings.SuspendLayout();
@@ -91,6 +92,7 @@
             this.groupBoxFieldMappings.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBoxFieldMappings.Controls.Add(this.checkBoxWarnMissingField);
             this.groupBoxFieldMappings.Controls.Add(this.label1);
             this.groupBoxFieldMappings.Controls.Add(this.labelRDPInfo);
             this.groupBoxFieldMappings.Controls.Add(this.labelRDPConnectionParameter);
@@ -353,9 +355,21 @@
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(484, 2);
             this.label1.TabIndex = 16;
-            // 
+            //
+            // checkBoxWarnMissingField
+            //
+            this.checkBoxWarnMissingField.AutoSize = true;
+            this.checkBoxWarnMissingField.Checked = true;
+            this.checkBoxWarnMissingField.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxWarnMissingField.Location = new System.Drawing.Point(7, 258);
+            this.checkBoxWarnMissingField.Name = "checkBoxWarnMissingField";
+            this.checkBoxWarnMissingField.Size = new System.Drawing.Size(268, 17);
+            this.checkBoxWarnMissingField.TabIndex = 17;
+            this.checkBoxWarnMissingField.Text = "&Warn when a referenced custom field is missing";
+            this.checkBoxWarnMissingField.UseVisualStyleBackColor = true;
+            //
             // Options
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(543, 478);
@@ -406,5 +420,6 @@
         private System.Windows.Forms.Label labelRDPConnectionParameter;
         private System.Windows.Forms.Label labelRDPInfo;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.CheckBox checkBoxWarnMissingField;
     }
 }

--- a/AdvancedConnectPlugin/GUI/Options.cs
+++ b/AdvancedConnectPlugin/GUI/Options.cs
@@ -49,7 +49,8 @@ namespace AdvancedConnectPlugin.GUI
             this.comboBoxRDPConncectionAddress.Text = plugin.settings.rdpConnectionAddressField;
             this.textBoxRDPConnectionMethod.Text = plugin.settings.rdpConnectionMethod;
             this.textBoxRDPCustomParameter.Text = plugin.settings.rdpCustomParameter;
-            
+            this.checkBoxWarnMissingField.Checked = plugin.settings.warnOnMissingFieldReference;
+
             //Check if database is open to load the custom values from db
             //(Lock configuration items if databse is closed)
             if (this.plugin.keepassHost.Database !=null && this.plugin.keepassHost.Database.IsOpen)
@@ -131,6 +132,7 @@ namespace AdvancedConnectPlugin.GUI
             this.plugin.settings.rdpConnectionAddressField = this.comboBoxRDPConncectionAddress.Text;
             this.plugin.settings.rdpConnectionMethod = this.textBoxRDPConnectionMethod.Text;
             this.plugin.settings.rdpCustomParameter = this.textBoxRDPCustomParameter.Text;
+            this.plugin.settings.warnOnMissingFieldReference = this.checkBoxWarnMissingField.Checked;
 
 
             //Write settings to settings file


### PR DESCRIPTION
Based on #25 — that one should be reviewed first, this builds on it.
Implements #26

#25 removes custom field references that cannot be resolved. Removing them silently means a misspelled field name disappears without a trace, which is hard to diagnose. This adds an optional warning that names the removed references.

### Behaviour

Before the application is launched, a dialog lists the references that were dropped:

    The following custom fields do not exist on this entry and were removed
    from the command line:

        {S:Connection-Adress}

    You can switch this warning off in the AdvancedConnect options.

The warning is shown **once per start**, not once per placeholder — `fillPlaceholders` is called several times per launch (path and options, five times for RDP), so the removed references are collected first and reported together.

### Setting

New checkbox in **Options → Main**, below the existing separator:
`Warn when a referenced custom field is missing`, enabled by default.

Persisted as `<WarnOnMissingFieldReference>` in `AdvancedConnect.xml`.

**Existing configuration files keep working unchanged.** The field defaults to `true`, so a file written by an earlier version — which does not contain the element — simply keeps the warning enabled. No migration step. Verified by deserializing an existing 25-entry configuration with the new class: all values read back correctly and the new setting defaults to `true`.

### When it fires

Only for fields the entry does **not have**. A field that exists but is empty is already substituted with an empty string by the placeholder engine and never reaches this code — measured against `Libs/KeePass.exe`:

| input | `SprEngine.Compile` result |
|---|---|
| `{S:Connection-Address}` (field set) | `host.example` |
| `{S:Connection-Empty}` (present, empty) | *(empty)* |
| `{S:Connection-Missing}` (no such field) | `{S:Connection-Missing}` |

### On the checkbox layout

The existing "Enable built-in RDP support" row uses a label plus a separate checkbox with an empty `Text`. I did not copy that pattern: a checkbox without its own text has no accessible name, so screen readers announce an unnamed control. The new checkbox carries its own label instead. It therefore looks slightly different from the RDP row above, but it sits in its own section below the separator, so the two do not compete visually.

I left the existing row alone — changing it belongs in its own change, not here.

### Verified

- compiles with `csc /langversion:5` against `Libs/KeePass.exe` (2.28) with `/warnaserror`,   no warnings; `.plgx` builds
- warning appears with the removed reference named, and disappears when the option is   switched off
- an existing `AdvancedConnect.xml` without the new element loads with the default 

### Note

If the fix for the crash on failed process start is merged as well, both changes marshal a dialog onto the UI thread with the same few lines. Happy to fold that into one small helper in a follow-up once both are in.
