### PR TITLE
Do not copy KeePass.exe into the build output

### DIFF
--- a/AdvancedConnectPlugin/AdvancedConnectPlugin.csproj
+++ b/AdvancedConnectPlugin/AdvancedConnectPlugin.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <Reference Include="KeePass">
       <HintPath>..\Libs\KeePass.exe</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
The released `AdvancedConnectPlugin.plgx` contains a copy of `KeePass.exe` (2.4 MB) and `KeePass.XmlSerializers.dll` (145 KB): both are copied into `bin\` during the build, and the PLGX is packaged from that directory.

`<Private>False</Private>` on the KeePass reference stops the copy and takes the package from 2.70 MB down to roughly 221 KB. The build itself is unaffected, as KeePass adjusts the KeePass reference before compiling the PLGX.

The remaining `bin\` and `obj\` content (the plugin's own assembly and PDB) is still packaged; removing that as well would require cleaning the source directory before packaging and is independent of this change.
